### PR TITLE
add `--type TYPE` option to specify generate type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ Make sure the `database_url` in the `config/environments/development.yml` is poi
 Then run:
 ```crystal
 shards build
-bin/db_scaffold (table_name | --all)
+bin/db_scaffold [--all|--type TYPE] (table_names)
+```
+
+If you want to generate only **model**, use `--type` option.
+```shell
+bin/db_scaffold --type model users
 ```
 
 ## Contributing

--- a/src/db_scaffold.cr
+++ b/src/db_scaffold.cr
@@ -1,10 +1,19 @@
 require "./db_scaffold/*"
 
-if table_name = ARGV[0]?
-  DbScaffold::Application.new(table_name)
+require "option_parser"
+
+recipe = DbScaffold::Recipe.new
+parser = OptionParser.parse([] of String) do |parser|
+  parser.banner = "Usage: bin/db_scaffold {table_names}"
+  parser.on("--type=TYPE", "Specify the generate type (default: scaffold)") {|v| recipe.type = v }
+  parser.on("--all", "Process all tables") { recipe.all = true }
+end
+parser.parse!
+recipe.tables = ARGV
+
+if recipe.valid?
+  DbScaffold::Application.new(recipe)
 else
   puts "Error: Table Name required\n".colorize(:red)
-  puts "bin/db_scaffold {table_name}".colorize(:cyan)
-  puts "or".colorize(:light_gray)
-  puts "bin/db_scaffold --all".colorize(:cyan)
+  puts parser.to_s.colorize(:cyan)
 end

--- a/src/db_scaffold/application.cr
+++ b/src/db_scaffold/application.cr
@@ -3,19 +3,16 @@ require "db"
 require "mysql"
 
 class DbScaffold::Application
-  def initialize(table_name)
-    if table_name == "--all"
-      table_names.each do |table_name|
-        generate table_name
-      end
-    else
-      generate table_name
+  def initialize(recipe : Recipe)
+    recipe.tables = table_names if recipe.all
+    recipe.tables.each do |table_name|
+      generate table_name, recipe.type
     end
   end
 
-  private def generate(table_name : String)
+  private def generate(table_name : String, type : String)
     table = Table.new(table_name)
-    `./bin/amber g scaffold #{table.name} #{table.fields}`
+    `./bin/amber g #{type} #{table.name} #{table.fields}`
   end
 
   private def table_names

--- a/src/db_scaffold/recipe.cr
+++ b/src/db_scaffold/recipe.cr
@@ -1,0 +1,11 @@
+module DbScaffold
+  class Recipe
+    property type   : String        = "scaffold"
+    property all    : Bool          = false
+    property tables : Array(String) = Array(String).new
+
+    def valid?
+      all || tables.any?
+    end
+  end
+end


### PR DESCRIPTION
In my usecase, I'd like to generate only models. This PR
- adds `--type TYPE` option (parsed by OptionParser)
- passes **the given type** rather than **scaffold** to amber if specified

```diff
-    `./bin/amber g scaffold #{table.name} #{table.fields}`
+    `./bin/amber g #{type} #{table.name} #{table.fields}`
```

#### usage

Works as `scaffold` in default. (backward compatibility)

```shell
% ./bin/db_scaffold promotions
% git status
        db/migrations/20180222043428606_create_promotion.sql
        spec/controllers/promotion_controller_spec.cr
        spec/models/promotion_spec.cr
        src/controllers/promotion_controller.cr
        src/models/promotion.cr
        src/views/promotion/
```

Respects `--type` option, and works as specified generator.

```shell
% ./bin/db_scaffold promotions --type model
% git status
        db/migrations/20180222043500942_create_promotion.sql
        spec/models/promotion_spec.cr
        src/models/promotion.cr
```

Delegates errors to amber for unknown types.

```shell
% ./bin/db_scaffold promotions --type xxx
...
Template not found (Exception)
  from ???
  from Amber::CLI::Template#generate<String, Nil>:(Process | Process::Status | Teeplate::Renderer | Nil)
```

Delegates errors to OptionParser for invalid args.

```
% ./bin/db_scaffold
Error: Table Name required

Usage: bin/db_scaffold {table_names}
    --type=TYPE                      one of 'model','controller',...
    --all                            Process all tables
```

Thanks again for your cool utils!